### PR TITLE
Implement rocket booking cancelation actions

### DIFF
--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -3,13 +3,13 @@ import '../styles/rocket.css';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Button, Badge } from 'react-bootstrap';
-import { reserveRocket } from '../redux/rockets/rocketSlices';
+import { reserveRocket, cancelReservation } from '../redux/rockets/rocketSlices';
 
 function Rocket({
   id, name, description, images, reserved,
 }) {
   const dispatch = useDispatch();
-  const CTAButton = reserved ? <Button variant="outline-secondary" className="CTABtn" id={id}>Cancel Reservation</Button> : <Button className="CTABtn" onClick={() => dispatch(reserveRocket(id))} type="button" variant="primary" id={id}>Reserve Rocket</Button>;
+  const CTAButton = reserved ? <Button variant="outline-secondary" onClick={() => dispatch(cancelReservation(id))} className="CTABtn" id={id}>Cancel Reservation</Button> : <Button className="CTABtn" onClick={() => dispatch(reserveRocket(id))} type="button" variant="primary" id={id}>Reserve Rocket</Button>;
   return (
     <div className="rocketCard" id={id}>
       <img src={images[0]} className="cardImage" alt="rocket" />

--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -10,7 +10,7 @@ function Rockets() {
     dispatch(getRockets());
   }, [dispatch]);
 
-  const mappedRockets = rockets.map((rocket) => (
+  const mappedRockets = rockets.slice(0, 4).map((rocket) => (
     <Rocket
       key={rocket.id}
       id={rocket.id}

--- a/src/redux/rockets/rocketSlices.js
+++ b/src/redux/rockets/rocketSlices.js
@@ -23,6 +23,12 @@ const rocketSlice = createSlice({
         rocket.reserved = !rocket.reserved;
       }
     },
+    cancelReservation: (state, action) => {
+      const rocket = state.rockets.find((rocket) => rocket.id === action.payload);
+      if (rocket) {
+        rocket.reserved = !rocket.reserved;
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -52,5 +58,5 @@ const rocketSlice = createSlice({
   },
 });
 
-export const { reserveRocket } = rocketSlice.actions;
+export const { reserveRocket, cancelReservation } = rocketSlice.actions;
 export default rocketSlice.reducer;


### PR DESCRIPTION
# Implement rocket booking cancelation actions
### In this Pull Request I implemented the `cancelReservation` button which when its clicked: 

- dispatch action
- updates `reserved : true` attribute to `reserved : false`
- removes `reserved` badge