### PR TITLE
display reserved rockets in my profile filters

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,3 +1,46 @@
-const Profile = () => <h2>My Profile</h2>;
+import React from 'react';
+import {
+  ListGroup, Container, Row, Col,
+} from 'react-bootstrap';
+import { useSelector } from 'react-redux';
+
+function Profile() {
+  const reservedRockets = useSelector((state) => state.rocket.reservedRockets);
+
+  return (
+    <Container style={{ marginTop: '2rem' }}>
+      <Row sm={1} md={2} lg={3}>
+        <Col className="missionsSection">
+          <h1 className="missionTitle">My Missions</h1>
+          <ListGroup>
+            <ListGroup.Item>Cras justo odio</ListGroup.Item>
+            <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+            <ListGroup.Item>Morbi leo risus</ListGroup.Item>
+            <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
+            <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
+          </ListGroup>
+        </Col>
+        <Col className="rocketsSection">
+          <h1 className="rocketTitle">My Rockets</h1>
+          <ListGroup>
+            {reservedRockets.map((rocket) => (
+              <ListGroup.Item key={rocket.id}>{rocket.name}</ListGroup.Item>
+            ))}
+          </ListGroup>
+        </Col>
+        <Col className="dragonsSection">
+          <h1 className="dragonTitle">My Dragons</h1>
+          <ListGroup>
+            <ListGroup.Item>Cras justo odio</ListGroup.Item>
+            <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+            <ListGroup.Item>Morbi leo risus</ListGroup.Item>
+            <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
+            <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
+          </ListGroup>
+        </Col>
+      </Row>
+    </Container>
+  );
+}
 
 export default Profile;

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -6,6 +6,18 @@ import { useSelector } from 'react-redux';
 
 function Profile() {
   const reservedRockets = useSelector((state) => state.rocket.reservedRockets);
+  let rocketRender;
+  if (reservedRockets.length === 0) {
+    rocketRender = <div>You have not reserved any Rocket</div>;
+  } else {
+    rocketRender = (
+      <ListGroup>
+        {reservedRockets.map((rocket) => (
+          <ListGroup.Item key={rocket.id}>{rocket.name}</ListGroup.Item>
+        ))}
+      </ListGroup>
+    );
+  }
 
   return (
     <Container style={{ marginTop: '2rem' }}>
@@ -22,11 +34,7 @@ function Profile() {
         </Col>
         <Col className="rocketsSection">
           <h1 className="rocketTitle">My Rockets</h1>
-          <ListGroup>
-            {reservedRockets.map((rocket) => (
-              <ListGroup.Item key={rocket.id}>{rocket.name}</ListGroup.Item>
-            ))}
-          </ListGroup>
+          {rocketRender}
         </Col>
         <Col className="dragonsSection">
           <h1 className="dragonTitle">My Dragons</h1>

--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -3,13 +3,13 @@ import '../styles/rocket.css';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Button, Badge } from 'react-bootstrap';
-import { reserveRocket, cancelReservation } from '../redux/rockets/rocketSlices';
+import { reserveRocket, cancelReservation, filterRockets } from '../redux/rockets/rocketSlices';
 
 function Rocket({
   id, name, description, images, reserved,
 }) {
   const dispatch = useDispatch();
-  const CTAButton = reserved ? <Button variant="outline-secondary" onClick={() => dispatch(cancelReservation(id))} className="CTABtn" id={id}>Cancel Reservation</Button> : <Button className="CTABtn" onClick={() => dispatch(reserveRocket(id))} type="button" variant="primary" id={id}>Reserve Rocket</Button>;
+  const CTAButton = reserved ? <Button variant="outline-secondary" onClick={() => { dispatch(cancelReservation(id)); dispatch(filterRockets()); }} className="CTABtn" id={id}>Cancel Reservation</Button> : <Button className="CTABtn" onClick={() => { dispatch(reserveRocket(id)); dispatch(filterRockets()); }} type="button" variant="primary" id={id}>Reserve Rocket</Button>;
   return (
     <div className="rocketCard" id={id}>
       <img src={images[0]} className="cardImage" alt="rocket" />


### PR DESCRIPTION
# Display reserved rockets in my profile filters.
### In this pull Request, I did the following:
- Add `filterRockets` reducer in the` rocketSlice.js` to filter reserved rockets.
- Add `reservedRockets` key in the initial state, to store reserved rockets.
- Add render structure for the list of reserved `mission` and `Dragon` .
- Render a list of all reserved rockets on the "`My profile`" page.